### PR TITLE
Do not blink the LED when idle

### DIFF
--- a/src/led/led.c
+++ b/src/led/led.c
@@ -49,6 +49,15 @@ void led_blinking_task() {
 #ifdef PICO_DEFAULT_LED_PIN_INVERTED
     state = !state;
 #endif
+    if (!led_mode) {
+        // in this mode the LED shall be off, not blinking
+        if (board_millis() - last_led_update_ms > 2) {
+            led_driver_color(0, 0, 0);
+            last_led_update_ms = board_millis();
+        }
+        return;
+    }
+
     uint32_t led_brightness = (led_mode & LED_BTNESS_MASK) >> LED_BTNESS_SHIFT;
     uint32_t led_color = (led_mode & LED_COLOR_MASK) >> LED_COLOR_SHIFT;
     uint32_t led_off = (led_mode & LED_OFF_MASK) >> LED_OFF_SHIFT;

--- a/src/led/led.h
+++ b/src/led/led.h
@@ -50,6 +50,19 @@ enum {
 // steady on
 #define LED_ON_NO_BLINK     ((1000 << LED_ON_SHIFT) | (0 << LED_OFF_SHIFT))
 
+#if defined(PICO_DEFAULT_LED_PIN) && !defined(PICO_DEFAULT_WS2812_PIN) && !defined(PIMORONI_TINY2040) && !defined(PIMORONI_TINY2350)
+// boards with plain old monochrome LED
+enum  {
+    MODE_NOT_MOUNTED = (MAX_BTNESS << LED_BTNESS_SHIFT) | (LED_COLOR_WHITE << LED_COLOR_SHIFT) | (500 << LED_ON_SHIFT) | (500 << LED_OFF_SHIFT),
+    MODE_MOUNTED     = 0, // no distraction when idle
+    MODE_SUSPENDED   = 0, // no distraction when idle
+    MODE_PROCESSING  = (MAX_BTNESS << LED_BTNESS_SHIFT) | (LED_COLOR_WHITE << LED_COLOR_SHIFT) | (50 << LED_ON_SHIFT)  | (50 << LED_OFF_SHIFT),
+    MODE_BUTTON      = (MAX_BTNESS << LED_BTNESS_SHIFT) | (LED_COLOR_WHITE << LED_COLOR_SHIFT) | (250 << LED_ON_SHIFT) | (250 << LED_OFF_SHIFT),
+    MODE_ALWAYS_ON   = UINT32_MAX,
+    MODE_ALWAYS_OFF  = 0
+};
+#else
+// boards with Neopixel or something similar
 enum  {
     MODE_NOT_MOUNTED = (MAX_BTNESS << LED_BTNESS_SHIFT) | (LED_COLOR_RED << LED_COLOR_SHIFT) | (500 << LED_ON_SHIFT) | (500 << LED_OFF_SHIFT),
     MODE_MOUNTED     = (MAX_BTNESS << LED_BTNESS_SHIFT) | (LED_COLOR_GREEN << LED_COLOR_SHIFT) | (500 << LED_ON_SHIFT) | (500 << LED_OFF_SHIFT),
@@ -60,6 +73,7 @@ enum  {
     MODE_ALWAYS_ON   = UINT32_MAX,
     MODE_ALWAYS_OFF  = 0
 };
+#endif
 
 extern void led_set_mode(uint32_t mode);
 extern uint32_t led_get_mode();


### PR DESCRIPTION
I have an issue like [Pico-Fido issue #101](https://github.com/polhenarejos/pico-fido/issues/101).

When I use fancy boards with onboard WS2812, slowly glowing the colorful LED is nice; but on the generic RP2 that sharp blinking the green LED is distracting and annoying. Of course I can turn it off completely via Comissioner. But I still want to use the LED to indicate that the user is prompted to interact.

So, here is my proposal: in the idle modes, non-dimmable LED should be off.