### PR TITLE
Update hid.c to fix esp32p4 build

### DIFF
--- a/src/usb/hid/hid.c
+++ b/src/usb/hid/hid.c
@@ -21,6 +21,7 @@
 #if defined(PICO_PLATFORM)
 #include "bsp/board.h"
 #elif defined(ESP_PLATFORM)
+#include "freertos/FreeRTOS.h"
 static portMUX_TYPE mutex = portMUX_INITIALIZER_UNLOCKED;
 #endif
 #else


### PR DESCRIPTION
In order to build pico-fido for a esp32p4 board the file `freertos/FreeRTOS.h` must be included. To test in pico-fido:

```bash
cd esp-idf/
./install.sh esp32p4
. ./export.sh
cd ..
idf.py set-target esp32p4
idf.py all
```