### PR TITLE
Use HMAC instead of PIN hashing with OTP key

### DIFF
--- a/src/crypto_utils.c
+++ b/src/crypto_utils.c
@@ -37,27 +37,22 @@ void double_hash_pin(const uint8_t *pin, uint16_t len, uint8_t output[32]) {
 }
 
 void double_hash_pin_otp(const uint8_t *pin, uint16_t len, uint8_t output[32]) {
-    uint8_t o1[32];
-    hash_multi_otp(pin, len, o1);
-    for (int i = 0; i < sizeof(o1); i++) {
-        o1[i] ^= pin[i % len];
+    if (otp_key_1) {
+        mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), otp_key_1, 32, pin, len, output);
+    } else {
+        double_hash_pin(pin, len, output);
     }
-    hash_multi_otp(o1, sizeof(o1), output);
 }
 
-void hash_multi_ext(const uint8_t *input, uint16_t len, const uint8_t *init, uint16_t len_init, uint8_t output[32]) {
+void hash_multi(const uint8_t *input, uint16_t len, uint8_t output[32]) {
     mbedtls_sha256_context ctx;
     mbedtls_sha256_init(&ctx);
     uint16_t iters = 256;
     mbedtls_sha256_starts(&ctx, 0);
-    if (init && len_init > 0) {
-        mbedtls_sha256_update(&ctx, init, len_init);
-    }
-    else {
+    
 #ifndef ENABLE_EMULATION
         mbedtls_sha256_update(&ctx, pico_serial.id, sizeof(pico_serial.id));
 #endif
-    }
 
     while (iters > len) {
         mbedtls_sha256_update(&ctx, input, len);
@@ -68,18 +63,6 @@ void hash_multi_ext(const uint8_t *input, uint16_t len, const uint8_t *init, uin
     }
     mbedtls_sha256_finish(&ctx, output);
     mbedtls_sha256_free(&ctx);
-}
-
-void hash_multi(const uint8_t *input, uint16_t len, uint8_t output[32]) {
-    hash_multi_ext(input, len, NULL, 0, output);
-}
-
-void hash_multi_otp(const uint8_t *input, uint16_t len, uint8_t output[32]) {
-    if (otp_key_1) {
-        hash_multi_ext(input, len, otp_key_1, 32, output);
-    } else {
-        hash_multi(input, len, output);
-    }
 }
 
 void hash256(const uint8_t *input, size_t len, uint8_t output[32]) {

--- a/src/crypto_utils.h
+++ b/src/crypto_utils.h
@@ -40,9 +40,7 @@
 
 extern void double_hash_pin(const uint8_t *pin, uint16_t len, uint8_t output[32]);
 extern void double_hash_pin_otp(const uint8_t *pin, uint16_t len, uint8_t output[32]);
-extern void hash_multi_ext(const uint8_t *input, uint16_t len, const uint8_t *init, uint16_t len_init, uint8_t output[32]);
 extern void hash_multi(const uint8_t *input, uint16_t len, uint8_t output[32]);
-extern void hash_multi_otp(const uint8_t *input, uint16_t len, uint8_t output[32]);
 extern void hash256(const uint8_t *input, size_t len, uint8_t output[32]);
 extern void generic_hash(mbedtls_md_type_t md, const uint8_t *input, size_t len, uint8_t *output);
 extern int aes_encrypt(const uint8_t *key, const uint8_t *iv, uint16_t key_size, int mode, uint8_t *data, uint16_t len);


### PR DESCRIPTION
To prevent possible problems of length extension attack with SHA-246, use HMAC for PIN verification when OTP key is present. See discussion https://github.com/polhenarejos/pico-fido/issues/187#issuecomment-3368855195