### PR TITLE
fix(hsm): reliable reset and re-provisioning on RP2350B — deep resets, core1 liveness, flash guards

### DIFF
--- a/src/apdu.c
+++ b/src/apdu.c
@@ -234,6 +234,14 @@ void *apdu_thread(void *arg) {
             queue_add_blocking(&card_to_usb_q, &flag);
         }
 
+        /* The dead-man's ping is a liveness probe, NOT a command: echo it and loop.
+         * Without this, a ping landing between APDU exchanges re-runs process_apdu()
+         * on the staged buffer — executing the previous state-changing command a
+         * SECOND time (measured 2026-08-03: duplicate execution broke the DKEK
+         * domain state mid-session and unwrapKey then failed SW=6400). */
+        if (m == EV_PING) {
+            continue;
+        }
         if (m == EV_VERIFY_CMD_AVAILABLE || m == EV_MODIFY_CMD_AVAILABLE) {
             set_res_sw(0x6f, 0x00);
             goto done;

--- a/src/fs/flash.c
+++ b/src/fs/flash.c
@@ -57,6 +57,15 @@ uintptr_t end_flash, end_rom_pool, start_rom_pool, end_data_pool, start_data_poo
 uintptr_t last_base;
 uint32_t num_files = 0;
 
+/* True if addr is inside the fs data region [start_data_pool, end_flash). Used by
+ * low_flash.c's corrupt-page guard — the region is partition-dependent (measured
+ * 2026-08-04: ~[1MB, 4MB) on this build, NOT [8MB, 16MB) as a hardcoded
+ * FLASH_SIZE_BYTES>>1 bound wrongly assumed, which made the guard drop every
+ * legitimate lazy write). */
+bool flash_addr_in_fs(uintptr_t addr) {
+    return addr >= start_data_pool && addr < end_flash;
+}
+
 void flash_set_bounds(uintptr_t start, uintptr_t end) {
     end_flash = end;
     end_rom_pool = end_flash - FLASH_DATA_HEADER_SIZE - 4;

--- a/src/fs/flash.h
+++ b/src/fs/flash.h
@@ -54,5 +54,6 @@ extern void flash_commit(void);
 extern bool flash_commit_sync(uint32_t timeout_ms);
 extern void low_flash_quiesce(void);
 extern void low_flash_unquiesce(void);
+extern bool low_flash_busy(void);
 
 #endif // _FLASH_H

--- a/src/fs/flash.h
+++ b/src/fs/flash.h
@@ -34,6 +34,7 @@ extern uint32_t flash_num_files(void);
 extern uint32_t flash_size(void);
 
 extern void flash_set_bounds(uintptr_t start, uintptr_t end);
+extern bool flash_addr_in_fs(uintptr_t addr);
 extern int flash_write_data_to_file(file_t *file, const_byte_array_t data);
 extern int flash_write_data_to_file_offset(file_t *file, const_byte_array_t data, uint32_t offset);
 extern int flash_program_block(uintptr_t addr, const_byte_array_t data);

--- a/src/fs/flash.h
+++ b/src/fs/flash.h
@@ -52,5 +52,7 @@ extern void flash_task(void);
 extern void low_flash_init(void);
 extern void flash_commit(void);
 extern bool flash_commit_sync(uint32_t timeout_ms);
+extern void low_flash_quiesce(void);
+extern void low_flash_unquiesce(void);
 
 #endif // _FLASH_H

--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -105,6 +105,45 @@ void low_flash_task(void);
 void low_flash_commit(void);
 bool low_flash_commit_sync(uint32_t timeout_ms);
 
+#if defined(PICO_PLATFORM) || defined(ESP_PLATFORM)
+/* Erase a multi-sector range ONE SECTOR PER CRITICAL SECTION.
+ *
+ * WHY: USB on RP2040 is interrupt-driven. flash_range_erase() has to run with interrupts
+ * disabled — XIP is unavailable while flash is being erased, so any ISR resident in flash would
+ * fault mid-erase — which means the USB stack is not serviced for the duration of the CALL, not
+ * the duration of a sector. INITIALIZE DEVICE erases the whole file region, so the old code
+ * handed flash_range_erase() a many-sector range and the device went silent on the bus long
+ * enough for the host to give up and drop it. The symptom is a Pico that "hangs" on
+ * `sc-hsm-tool --initialize` and needs a PHYSICAL REPLUG to come back — see
+ * polhenarejos/pico-hsm#9 (LIBUSB_ERROR_TIMEOUT / "Card not transacted").
+ *
+ * That behaviour also makes the device unusable in a remote/datacenter deployment, where nobody
+ * can walk over and reseat the USB connector.
+ *
+ * Erasing a single sector per critical section bounds each blackout to one sector erase
+ * (~30-45ms on RP2040, well inside what a host tolerates) and gives the USB IRQ a window between
+ * sectors, so the device stays enumerated across an erase of any size. TOTAL erase time is
+ * unchanged — this only changes how the blackout is distributed.
+ *
+ * The caller keeps the multicore lockout held across the whole range: the lockout parks core 1,
+ * while save_and_disable_interrupts() is per-core (PRIMASK), so restoring here re-enables the
+ * USB IRQ on core 0 without letting core 1 loose against flash mid-erase.
+ *
+ * On ESP_PLATFORM the interrupt macros above are no-ops and esp_partition_erase_range() does not
+ * block the USB stack, so this is simply a chunked erase there and behaviour is unchanged.
+ */
+static void flash_range_erase_chunked(uint32_t offset, size_t total_bytes) {
+    if (total_bytes < FLASH_SECTOR_SIZE) {
+        total_bytes = FLASH_SECTOR_SIZE;
+    }
+    for (size_t done = 0; done < total_bytes; done += FLASH_SECTOR_SIZE) {
+        uint32_t ints = save_and_disable_interrupts();
+        flash_range_erase(offset + done, FLASH_SECTOR_SIZE);
+        restore_interrupts(ints);
+    }
+}
+#endif
+
 void low_flash_task(void){
     if (mutex_try_enter(&mtx_flash, NULL) == true) {
         if (locked_out == true && flash_available == true && ready_pages > 0) {
@@ -140,9 +179,10 @@ void low_flash_task(void){
                         continue;
                     }
                     //printf("WRITTING\n");
-                    uint32_t ints = save_and_disable_interrupts();
-                    flash_range_erase(flash_pages[r].address - XIP_BASE, flash_pages[r].page_size ? ((int) (flash_pages[r].page_size / FLASH_SECTOR_SIZE)) * FLASH_SECTOR_SIZE : FLASH_SECTOR_SIZE);
-                    restore_interrupts(ints);
+                    /* Chunked: a whole-region erase here is what drops the device off the USB
+                     * bus during INITIALIZE DEVICE. See flash_range_erase_chunked() above. */
+                    flash_range_erase_chunked(flash_pages[r].address - XIP_BASE,
+                                              flash_pages[r].page_size ? ((size_t) (flash_pages[r].page_size / FLASH_SECTOR_SIZE)) * FLASH_SECTOR_SIZE : FLASH_SECTOR_SIZE);
                     if (multicore_lockout_end_timeout_us(1000) == false) {
                         printf("WARN: FLASH LOCKOUT END TIMEOUT\n");
                         continue;

--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -149,10 +149,22 @@ void low_flash_task(void){
         if (locked_out == true && flash_available == true && ready_pages > 0) {
             //printf(" DO_FLASH AVAILABLE\n");
             for (int r = 0; r < TOTAL_FLASH_PAGES; r++) {
+                if (flash_pages[r].ready == true || flash_pages[r].erase == true) {
+                    uintptr_t a = flash_pages[r].address;
+                    uint32_t off = a - XIP_BASE;
+                    if (a < XIP_BASE || off < (FLASH_SIZE_BYTES >> 1) || off >= FLASH_SIZE_BYTES) {
+                        printf("ERROR: flash_pages[%d] has out-of-region address %p — dropping entry, NOT erasing\n",
+                               r, (void *) a);
+                        flash_pages[r].ready = false;
+                        flash_pages[r].erase = false;
+                        ready_pages--;
+                        continue;
+                    }
+                }
                 if (flash_pages[r].ready == true) {
 #if defined(PICO_PLATFORM) || defined(ESP_PLATFORM)
                     //printf("WRITTING %X\n",flash_pages[r].address-XIP_BASE);
-                    if (multicore_lockout_start_timeout_us(1000) == false) {
+                    if (multicore_lockout_start_timeout_us(100000) == false) {
                         printf("WARN: FLASH LOCKOUT START TIMEOUT\n");
                         continue;
                     }
@@ -161,8 +173,16 @@ void low_flash_task(void){
                     flash_range_erase(flash_pages[r].address - XIP_BASE, FLASH_SECTOR_SIZE);
                     flash_range_program(flash_pages[r].address - XIP_BASE, flash_pages[r].page, FLASH_SECTOR_SIZE);
                     restore_interrupts(ints);
-                    if (multicore_lockout_end_timeout_us(1000) == false) {
-                        printf("WARN: FLASH LOCKOUT END TIMEOUT\n");
+                    if (multicore_lockout_end_timeout_us(100000) == false) {
+                        /* A timed-out END can orphan core1 in the lockout victim handler
+                         * forever (measured 2026-08-02: core1 parked in
+                         * multicore_lockout_handler, card mute). The 1ms default was far
+                         * inside normal IRQ/entry latency. Re-sync with a full start+end
+                         * pair: start on an already-locked victim returns immediately,
+                         * and the end then releases it. */
+                        printf("WARN: FLASH LOCKOUT END TIMEOUT — resyncing core1\n");
+                        multicore_lockout_start_timeout_us(100000);
+                        multicore_lockout_end_timeout_us(100000);
                         continue;
                     }
                     //printf("WRITEN %X !\n",flash_pages[r].address);
@@ -174,7 +194,7 @@ void low_flash_task(void){
                 }
                 else if (flash_pages[r].erase == true) {
 #if defined(PICO_PLATFORM) || defined(ESP_PLATFORM)
-                    if (multicore_lockout_start_timeout_us(1000) == false) {
+                    if (multicore_lockout_start_timeout_us(100000) == false) {
                         printf("WARN: FLASH LOCKOUT START TIMEOUT\n");
                         continue;
                     }
@@ -183,8 +203,16 @@ void low_flash_task(void){
                      * bus during INITIALIZE DEVICE. See flash_range_erase_chunked() above. */
                     flash_range_erase_chunked(flash_pages[r].address - XIP_BASE,
                                               flash_pages[r].page_size ? ((size_t) (flash_pages[r].page_size / FLASH_SECTOR_SIZE)) * FLASH_SECTOR_SIZE : FLASH_SECTOR_SIZE);
-                    if (multicore_lockout_end_timeout_us(1000) == false) {
-                        printf("WARN: FLASH LOCKOUT END TIMEOUT\n");
+                    if (multicore_lockout_end_timeout_us(100000) == false) {
+                        /* A timed-out END can orphan core1 in the lockout victim handler
+                         * forever (measured 2026-08-02: core1 parked in
+                         * multicore_lockout_handler, card mute). The 1ms default was far
+                         * inside normal IRQ/entry latency. Re-sync with a full start+end
+                         * pair: start on an already-locked victim returns immediately,
+                         * and the end then releases it. */
+                        printf("WARN: FLASH LOCKOUT END TIMEOUT — resyncing core1\n");
+                        multicore_lockout_start_timeout_us(100000);
+                        multicore_lockout_end_timeout_us(100000);
                         continue;
                     }
 #else

--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -343,6 +343,17 @@ static bool low_flash_available(void) {
     return available;
 }
 
+/* Public idle check for reset scheduling: true while the flash layer has queued or
+ * in-flight work. A reset that lands while lazy writes are still pending leaves a
+ * half-written file system and the next boot may fail to present the card (measured
+ * 2026-08-03: boot mute after init-on-blank-fs, repeatedly). */
+bool low_flash_busy(void) {
+    mutex_enter_blocking(&mtx_flash);
+    bool busy = flash_available || ready_pages > 0;
+    mutex_exit(&mtx_flash);
+    return busy;
+}
+
 bool low_flash_commit_sync(uint32_t timeout_ms) {
 #if defined(PICO_PLATFORM)
     // Core 0 owns low_flash_task(). Waiting for it from core 0 would prevent

--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -212,6 +212,23 @@ void low_flash_task(void){
     }
 }
 
+/* Take the flash mutex and NEVER give it back. Every flash operation in this layer — queued
+ * erases, commits, background page handling — enters mtx_flash (low_flash_task only via
+ * try_enter, so a held mutex makes it skip), and the underlying SDK erase/program calls are
+ * synchronous, so once the mutex is held the flash chip is IDLE and stays idle. Intended for
+ * use immediately before a chip reset: a reset landing while the flash chip is internally busy
+ * is the measured cause of the intermittent post-reset boot wedge (see cmd_initialize.c in
+ * pico-hsm). Not re-entrant; the caller is expected to reset the chip before ever releasing. */
+void low_flash_quiesce(void) {
+    mutex_enter_blocking(&mtx_flash);
+}
+
+/* Release the mutex taken by low_flash_quiesce(). Only for the path where the reset the
+ * quiesce was taken for did NOT fire and the device stays alive — see cmd_initialize.c. */
+void low_flash_unquiesce(void) {
+    mutex_exit(&mtx_flash);
+}
+
 #ifdef PICO_RP2040
 void phymarker_write(void);
 #endif

--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -151,8 +151,7 @@ void low_flash_task(void){
             for (int r = 0; r < TOTAL_FLASH_PAGES; r++) {
                 if (flash_pages[r].ready == true || flash_pages[r].erase == true) {
                     uintptr_t a = flash_pages[r].address;
-                    uint32_t off = a - XIP_BASE;
-                    if (a < XIP_BASE || off < (FLASH_SIZE_BYTES >> 1) || off >= FLASH_SIZE_BYTES) {
+                    if (!flash_addr_in_fs(a)) {
                         printf("ERROR: flash_pages[%d] has out-of-region address %p — dropping entry, NOT erasing\n",
                                r, (void *) a);
                         flash_pages[r].ready = false;

--- a/src/main.c
+++ b/src/main.c
@@ -117,6 +117,9 @@ void execute_tasks(void) {
     rest_task();
 #endif
     usb_task();
+#ifdef PICO_PLATFORM
+    card_watchdog_task();
+#endif
     led_blinking_task();
 #ifdef ENABLE_LVGL_UI
     platform_ui_task();

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,25 @@
 #include "bsp/board.h"
 #include "hardware/structs/ioqspi.h"
 #include "pico/stdio.h"
+#include "pico/bootrom.h"
+#include "boot/picoboot_constants.h"
+#endif
+
+#if defined(PICO_PLATFORM)
+/* The SDK's hard_assertion_failure() is __weak; override it. The default path is
+ * panic() -> __breakpoint -> _exit: a silent, permanent brick that needs a physical
+ * replug — measured 2026-08-03 (a corrupt flash_pages entry hit
+ * hard_assert(flash_offs + count <= PICO_FLASH_SIZE_BYTES) and the device sat
+ * catatonic for a day). A smartcard that cannot recover itself is not one. Reboot
+ * via the bootrom instead: each boot is a fresh roll, and the core1 launch-verify
+ * and dead-man's switch do their jobs from there. */
+void hard_assertion_failure(void) {
+    printf("PANIC: hard assert failed — rebooting via rom_reboot\n");
+    rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_NORMAL, 1, 0, 0);
+    while (1) {
+        tight_loop_contents();
+    }
+}
 #endif
 
 #include "random.h"

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,9 @@
 #include "pico/stdio.h"
 #include "pico/bootrom.h"
 #include "boot/picoboot_constants.h"
+#include "hardware/powman.h"
+#include "hardware/structs/psm.h"
+#include "hardware/regs/psm.h"
 #endif
 
 #if defined(PICO_PLATFORM)
@@ -184,6 +187,24 @@ int main(void) {
 #ifdef PICO_PLATFORM
     board_init();
     stdio_init_all();
+
+    /* Make EVERY watchdog-family reset a FULL switched-core power cycle. The default
+     * watchdog reset (PSM_WDSEL minus ROSC/XOSC) leaves the switched core domain
+     * powered and was measured to wedge the warm boot ~5-10% of resets on RP2350B —
+     * cores never start, identically across watchdog_reboot() and rom_reboot()
+     * (2026-08-02/03 forensic record in regalia hardware/pico-hsm/). POWMAN_WDSEL
+     * RESET_SWCORE makes the reset power-cycle the switched domain and run the full
+     * PSM sequence — "the same effect as a power-on reset for the switched core
+     * power domain" (RP2350 datasheet). RESET_POWMAN_ASYNC restores powman defaults
+     * without depending on clk_ref; because it restores defaults, this register must
+     * be re-armed on EVERY boot — hence here, first thing. PSM_WDSEL all-ones per
+     * the datasheet note (powman ignores watchdog resets that don't select CLOCKS
+     * or earlier). */
+    powman_set_bits(&powman_hw->wdsel,
+                    POWMAN_WDSEL_RESET_POWMAN_ASYNC_BITS |
+                    POWMAN_WDSEL_RESET_SWCORE_BITS |
+                    POWMAN_WDSEL_RESET_PSM_BITS);
+    psm_hw->wdsel = PSM_WDSEL_BITS;
 #endif
 
 #else

--- a/src/usb/ccid/ccid.c
+++ b/src/usb/ccid/ccid.c
@@ -30,6 +30,16 @@
 #include "ccid.h"
 #include "apdu.h"
 #include "usb.h"
+#if defined(PICO_PLATFORM) && defined(PICOKEYS_REMOTE_RESET)
+#include "pico/usb_reset_interface.h"
+#include "pico/bootrom.h"
+#include "hardware/watchdog.h"
+/* Grace period before the reset fires, so the control transfer is acknowledged first and the
+ * host sees the request succeed rather than a bare disconnect. */
+#ifndef PICOKEYS_REMOTE_RESET_DELAY_MS
+#define PICOKEYS_REMOTE_RESET_DELAY_MS 100
+#endif
+#endif
 
 #if MAX_RES_APDU_DATA_SIZE > MAX_CMD_APDU_DATA_SIZE
 #define USB_BUF_SIZE (MAX_RES_APDU_DATA_SIZE + 20 + 9)
@@ -443,30 +453,36 @@ static bool ccid_control_xfer_cb(uint8_t __unused rhport,
                 request->bRequest,
                 request->wValue,
                 request->wLength);
-/*
- #if PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL
+#if defined(PICO_PLATFORM) && defined(PICOKEYS_REMOTE_RESET)
+        /* Remote reset over USB. OFF unless the build explicitly opts in — see the CMake option
+         * PICOKEYS_REMOTE_RESET. This block shipped commented out, which is why the ONLY way to
+         * recover a wedged device was to physically reseat the connector. That is fine on a desk
+         * and impossible in a datacenter.
+         *
+         * SECURITY — read before enabling. RESET_REQUEST_BOOTSEL drops the device into the
+         * bootloader, i.e. it allows REMOTE FIRMWARE REPLACEMENT by any process that can reach
+         * the USB device. On a development or staging token that is the point: firmware updates
+         * and recovery without hands on the hardware. On a token holding anything of value it is
+         * an unauthenticated code-load path and must stay off. Neither request is authenticated
+         * — there is no PIN check here, by construction, because a wedged device cannot verify a
+         * PIN. That is precisely why this is opt-in at BUILD time rather than runtime: the
+         * decision is made when the firmware is produced, not by whatever is talking to it.
+         *
+         * Reboot only exposes no key material by itself; BOOTSEL does, indirectly, by allowing
+         * firmware that could then read flash. Enable accordingly. */
         if (request->bRequest == RESET_REQUEST_BOOTSEL) {
- #ifdef PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED
-            uint gpio_mask = 1u << PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED;
- #else
-            uint gpio_mask = 0u;
- #endif
- #if !PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
-            if (request->wValue & 0x100) {
-                gpio_mask = 1u << (request->wValue >> 9u);
-            }
- #endif
-            reset_usb_boot(gpio_mask, (request->wValue & 0x7f) | PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
-            // does not return, otherwise we'd return true
+            reset_usb_boot(0, 0);
+            // does not return
         }
- #endif
- #if PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT
         if (request->bRequest == RESET_REQUEST_FLASH) {
-            watchdog_reboot(0, 0, PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS);
+            /* Plain watchdog reset, deliberately NOT usb_secure_reboot_now(): the latter zeroes
+             * heap and stack first and was measured to HANG an RP2350 outright, leaving the bus
+             * without re-enumerating. A recovery path that can itself wedge the device is worse
+             * than none. */
+            watchdog_reboot(0, 0, PICOKEYS_REMOTE_RESET_DELAY_MS);
             return true;
         }
- #endif
- */
+#endif
         return true;
     }
     return false;

--- a/src/usb/ccid/ccid.c
+++ b/src/usb/ccid/ccid.c
@@ -30,16 +30,6 @@
 #include "ccid.h"
 #include "apdu.h"
 #include "usb.h"
-#if defined(PICO_PLATFORM) && defined(PICOKEYS_REMOTE_RESET)
-#include "pico/usb_reset_interface.h"
-#include "pico/bootrom.h"
-#include "hardware/watchdog.h"
-/* Grace period before the reset fires, so the control transfer is acknowledged first and the
- * host sees the request succeed rather than a bare disconnect. */
-#ifndef PICOKEYS_REMOTE_RESET_DELAY_MS
-#define PICOKEYS_REMOTE_RESET_DELAY_MS 100
-#endif
-#endif
 
 #if MAX_RES_APDU_DATA_SIZE > MAX_CMD_APDU_DATA_SIZE
 #define USB_BUF_SIZE (MAX_RES_APDU_DATA_SIZE + 20 + 9)
@@ -453,36 +443,30 @@ static bool ccid_control_xfer_cb(uint8_t __unused rhport,
                 request->bRequest,
                 request->wValue,
                 request->wLength);
-#if defined(PICO_PLATFORM) && defined(PICOKEYS_REMOTE_RESET)
-        /* Remote reset over USB. OFF unless the build explicitly opts in — see the CMake option
-         * PICOKEYS_REMOTE_RESET. This block shipped commented out, which is why the ONLY way to
-         * recover a wedged device was to physically reseat the connector. That is fine on a desk
-         * and impossible in a datacenter.
-         *
-         * SECURITY — read before enabling. RESET_REQUEST_BOOTSEL drops the device into the
-         * bootloader, i.e. it allows REMOTE FIRMWARE REPLACEMENT by any process that can reach
-         * the USB device. On a development or staging token that is the point: firmware updates
-         * and recovery without hands on the hardware. On a token holding anything of value it is
-         * an unauthenticated code-load path and must stay off. Neither request is authenticated
-         * — there is no PIN check here, by construction, because a wedged device cannot verify a
-         * PIN. That is precisely why this is opt-in at BUILD time rather than runtime: the
-         * decision is made when the firmware is produced, not by whatever is talking to it.
-         *
-         * Reboot only exposes no key material by itself; BOOTSEL does, indirectly, by allowing
-         * firmware that could then read flash. Enable accordingly. */
+/*
+ #if PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL
         if (request->bRequest == RESET_REQUEST_BOOTSEL) {
-            reset_usb_boot(0, 0);
-            // does not return
+ #ifdef PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED
+            uint gpio_mask = 1u << PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED;
+ #else
+            uint gpio_mask = 0u;
+ #endif
+ #if !PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
+            if (request->wValue & 0x100) {
+                gpio_mask = 1u << (request->wValue >> 9u);
+            }
+ #endif
+            reset_usb_boot(gpio_mask, (request->wValue & 0x7f) | PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+            // does not return, otherwise we'd return true
         }
+ #endif
+ #if PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT
         if (request->bRequest == RESET_REQUEST_FLASH) {
-            /* Plain watchdog reset, deliberately NOT usb_secure_reboot_now(): the latter zeroes
-             * heap and stack first and was measured to HANG an RP2350 outright, leaving the bus
-             * without re-enumerating. A recovery path that can itself wedge the device is worse
-             * than none. */
-            watchdog_reboot(0, 0, PICOKEYS_REMOTE_RESET_DELAY_MS);
+            watchdog_reboot(0, 0, PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS);
             return true;
         }
-#endif
+ #endif
+ */
         return true;
     }
     return false;

--- a/src/usb/usb.c
+++ b/src/usb/usb.c
@@ -22,6 +22,7 @@
 #include "pico_time.h"
 #if defined(PICO_PLATFORM)
 #include "pico/bootrom.h"
+#include "boot/picoboot_constants.h"
 #include "pico/multicore.h"
 #include "pico/time.h"
 #include "hardware/sync.h"
@@ -301,6 +302,37 @@ void card_init_core1(void) {
 volatile uint16_t finished_data_size = 0;
 
 #if defined(PICO_PLATFORM)
+/* Full-chip reset via the BOOTROM's own reboot facility. Why not the alternatives:
+ *  - AIRCR.SYSRESETREQ: resets only the asserting core on RP2040/RP2350 (the datasheet's
+ *    generic ARM text is wrong for these parts; measured here 2026-08-02 as a complete
+ *    no-op — RAM statics survived the write).
+ *  - SDK watchdog_reboot(): full-chip, but measured to wedge the post-reset boot ~7% of
+ *    cycles (shapes A/B in the forensic record).
+ *  - rom_reboot(): still watchdog-based, but it is the bootrom's own sequenced path — the
+ *    same mechanism every UF2 flash-update reboot uses, the most field-exercised warm
+ *    reset this chip has.
+ * Quiesce flash first: no flash op may be in flight when the reset lands. */
+static void chip_reset_now(void) {
+    low_flash_quiesce();
+    printf("CARD: rebooting via bootrom rom_reboot\n");
+    int rc = rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_NORMAL, 1, 0, 0);
+    /* The reboot is armed asynchronously; if the call returned an error, stay alive. */
+    if (rc != 0) {
+        low_flash_unquiesce();
+        printf("CARD: ERROR rom_reboot refused (%d) — staying alive\n", rc);
+    }
+}
+
+/* Deferred chip reset, fired by card_watchdog_task() from core0's main loop. Exists
+ * because a reset must never run inside an APDU handler: the response is transmitted
+ * after the handler returns, so a synchronous reset lands mid-command (measured:
+ * Transmit failed on the host). */
+static uint64_t scheduled_reset_at_ms = 0;   /* 0 = none pending */
+
+void schedule_chip_reset(uint32_t delay_ms) {
+    scheduled_reset_at_ms = board_millis() + delay_ms;
+}
+
 /* Hard reset via AIRCR.SYSRESETREQ, with a bounded attempt budget kept in watchdog
  * scratch[1] (survives warm resets). Used when core1 cannot be launched: each boot is
  * an independent dice roll, so resetting again converges — but a device that NEVER
@@ -318,12 +350,7 @@ static void chip_reset_bounded(void) {
         return;
     }
     printf("CARD: core1 launch failed, resetting chip (attempt %lu)\n", (unsigned long) attempts);
-    __asm volatile("dsb sy" ::: "memory");
-    scb_hw->aircr = (0x05FAu << M33_AIRCR_VECTKEY_LSB)
-                    | M33_AIRCR_SYSRESETREQ_BITS | M33_AIRCR_SYSRESETREQS_BITS;
-    __asm volatile("dsb sy" ::: "memory");
-    busy_wait_ms(2000);
-    printf("CARD: ERROR SYSRESETREQ did not reset — staying alive-dark\n");
+    chip_reset_now();
 }
 
 /* Launch func on core1 and VERIFY it actually started (the launch handshake can
@@ -515,6 +542,14 @@ void card_watchdog_task(void) {
         return;
     }
     wd_last_run_ms = now;
+
+    /* A scheduled chip reset outranks everything else on this pass. */
+    if (scheduled_reset_at_ms != 0 && (long long) (now - scheduled_reset_at_ms) >= 0) {
+        scheduled_reset_at_ms = 0;
+        printf("CARD: scheduled reset firing\n");
+        chip_reset_now();
+        return;
+    }
 
     if (card_locked_itf == ITF_TOTAL || card_locked_func == NULL) {
         ping_sent_ms = 0;

--- a/src/usb/usb.c
+++ b/src/usb/usb.c
@@ -28,6 +28,7 @@
 #include "hardware/sync.h"
 #include "hardware/watchdog.h"
 #include "hardware/structs/scb.h"
+#include "hardware/powman.h"
 #define multicore_launch_func_core1(a) multicore_launch_core1((void (*) (void))a)
 #endif
 #include "apdu.h"
@@ -310,15 +311,32 @@ volatile uint16_t finished_data_size = 0;
  *    same mechanism every UF2 flash-update reboot uses, the most field-exercised warm
  *    reset this chip has.
  * Quiesce flash first: no flash op may be in flight when the reset lands. */
-static void chip_reset_now(void) {
+static void chip_reset_now(bool deep) {
+    /* Two measured-good configurations (2026-08-03/04):
+     *  - deep == false (scheduled reset after INITIALIZE): drain-guarded, then
+     *    rom_reboot with the POWMAN_WDSEL deep-reset bits CLEARED. This combination
+     *    ran 22/23 post-wipe recovery cycles; deep resets after a wipe came back
+     *    mute in 4/4 attempts. main.c re-arms WDSEL on every boot.
+     *  - deep == true (recovery resets): watchdog_reboot with WDSEL armed —
+     *    power-cycles the switched core domain; hammered 100/100 on an idle card.
+     * Quiesce flash first either way: no flash op may be in flight at the reset. */
     low_flash_quiesce();
-    printf("CARD: rebooting via bootrom rom_reboot\n");
-    int rc = rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_NORMAL, 1, 0, 0);
-    /* The reboot is armed asynchronously; if the call returned an error, stay alive. */
-    if (rc != 0) {
-        low_flash_unquiesce();
-        printf("CARD: ERROR rom_reboot refused (%d) — staying alive\n", rc);
+    if (deep) {
+        printf("CARD: rebooting via watchdog (deep: SWCORE power-cycle)\n");
+        watchdog_reboot(0, 0, 0);
     }
+    else {
+        powman_clear_bits(&powman_hw->wdsel,
+                          POWMAN_WDSEL_RESET_POWMAN_ASYNC_BITS |
+                          POWMAN_WDSEL_RESET_SWCORE_BITS |
+                          POWMAN_WDSEL_RESET_PSM_BITS);
+        printf("CARD: rebooting via rom_reboot (shallow)\n");
+        rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_NORMAL, 1, 0, 0);
+    }
+    /* Unreachable if the reset took. Stay alive and working if it did not. */
+    busy_wait_ms(2000);
+    low_flash_unquiesce();
+    printf("CARD: ERROR reset did not fire (deep=%d) — staying alive\n", (int) deep);
 }
 
 /* Deferred chip reset, fired by card_watchdog_task() from core0's main loop. Exists
@@ -348,7 +366,7 @@ static void chip_reset_bounded(void) {
         return;
     }
     printf("CARD: core1 launch failed, resetting chip (attempt %lu)\n", (unsigned long) attempts);
-    chip_reset_now();
+    chip_reset_now(true);
 }
 
 /* Launch func on core1 and VERIFY it actually started (the launch handshake can
@@ -541,11 +559,17 @@ void card_watchdog_task(void) {
     }
     wd_last_run_ms = now;
 
-    /* A scheduled chip reset outranks everything else on this pass. */
+    /* A scheduled chip reset outranks everything else on this pass — but never fire
+     * it while the flash layer still has lazy work queued: a reset landing mid-drain
+     * leaves a half-written file system and the next boot can fail to present the
+     * card. Wait for the drain, bounded so a stuck queue cannot defer it forever. */
     if (scheduled_reset_at_ms != 0 && (long long) (now - scheduled_reset_at_ms) >= 0) {
+        if (low_flash_busy() && (long long) (now - scheduled_reset_at_ms) < 30000) {
+            return;   /* retry next pass */
+        }
         scheduled_reset_at_ms = 0;
         printf("CARD: scheduled reset firing\n");
-        chip_reset_now();
+        chip_reset_now(false);
         return;
     }
 

--- a/src/usb/usb.c
+++ b/src/usb/usb.c
@@ -23,7 +23,10 @@
 #if defined(PICO_PLATFORM)
 #include "pico/bootrom.h"
 #include "pico/multicore.h"
+#include "pico/time.h"
 #include "hardware/sync.h"
+#include "hardware/watchdog.h"
+#include "hardware/structs/scb.h"
 #define multicore_launch_func_core1(a) multicore_launch_core1((void (*) (void))a)
 #endif
 #include "apdu.h"
@@ -242,6 +245,23 @@ bool is_busy(void) {
     return timeout > 0;
 }
 
+#if defined(PICO_PLATFORM)
+/* State for the core1 dead-man's switch (card_watchdog_task(), bottom of file). */
+#define EV_PING                 0x10000u
+#define EV_PING_ECHO            (EV_PING + 1)
+#define CARD_PING_INTERVAL_MS   2000
+#define CARD_PING_TIMEOUT_MS    1000
+#define CMD_DEADLINE_MS         300000u   /* 180s commit cap + erase margin */
+
+static volatile bool cmd_in_flight = false;
+static uint64_t cmd_started_ms = 0;
+static uint64_t ping_sent_ms = 0;         /* 0 = no ping outstanding */
+static uint64_t core1_last_ok_ms = 0;
+static uint64_t wd_last_run_ms = 0;
+
+static void card_note_core1_alive(void);
+#endif
+
 void usb_send_event(uint32_t flag) {
 #ifndef ENABLE_EMULATION
     mutex_enter_blocking(&mutex);
@@ -249,6 +269,10 @@ void usb_send_event(uint32_t flag) {
     queue_add_blocking(&usb_to_card_q, &flag);
     if (flag == EV_CMD_AVAILABLE) {
         timeout_start();
+#if defined(PICO_PLATFORM)
+        cmd_in_flight = true;
+        cmd_started_ms = board_millis();
+#endif
     }
 #ifndef ENABLE_EMULATION
     mutex_exit(&mutex);
@@ -260,11 +284,70 @@ void usb_send_event(uint32_t flag) {
     }
 }
 
+/* Core1 liveness flag, cleared by card_start() before each launch and set by
+ * card_init_core1() — the first thing every launched card function runs (apdu.c).
+ * Exists because the SDK's multicore launch handshake CAN report success while core1
+ * never starts: measured 2026-08-02 via SWD on a live failure — core1 parked in the
+ * bootrom's wait-for-launch loop (polling SIO FIFO_ST), one unread word in the FIFO
+ * (VLD=1), core0 convinced the launch succeeded. The card then enumerates USB (TinyUSB
+ * runs on core0) but never answers an APDU. */
+static volatile bool core1_alive = false;
+
 void card_init_core1(void) {
+    core1_alive = true;
     low_flash_init_core1();
 }
 
 volatile uint16_t finished_data_size = 0;
+
+#if defined(PICO_PLATFORM)
+/* Hard reset via AIRCR.SYSRESETREQ, with a bounded attempt budget kept in watchdog
+ * scratch[1] (survives warm resets). Used when core1 cannot be launched: each boot is
+ * an independent dice roll, so resetting again converges — but a device that NEVER
+ * gets core1 back must stop rolling and stay alive-dark (enumerated, not answering)
+ * rather than reset-loop forever. */
+#define CORE1_BOOT_ATTEMPTS_MAX 5
+
+static void chip_reset_bounded(void) {
+    watchdog_hw->scratch[4] += 1;
+    uint32_t attempts = watchdog_hw->scratch[1] + 1;
+    watchdog_hw->scratch[1] = attempts;
+    if (attempts > CORE1_BOOT_ATTEMPTS_MAX) {
+        printf("CARD: core1 unrecoverable after %lu boots — staying alive-dark\n",
+               (unsigned long) attempts);
+        return;
+    }
+    printf("CARD: core1 launch failed, resetting chip (attempt %lu)\n", (unsigned long) attempts);
+    __asm volatile("dsb sy" ::: "memory");
+    scb_hw->aircr = (0x05FAu << M33_AIRCR_VECTKEY_LSB)
+                    | M33_AIRCR_SYSRESETREQ_BITS | M33_AIRCR_SYSRESETREQS_BITS;
+    __asm volatile("dsb sy" ::: "memory");
+    busy_wait_ms(2000);
+    printf("CARD: ERROR SYSRESETREQ did not reset — staying alive-dark\n");
+}
+
+/* Launch func on core1 and VERIFY it actually started (the launch handshake can
+ * complete against stale FIFO data while core1 stays parked in the bootrom — the
+ * failure core1_alive exists to catch). Returns core1_alive. */
+static bool card_launch_verified(void *(*func)(void *)) {
+    for (int attempt = 0; attempt < 3 && !core1_alive; attempt++) {
+        if (attempt > 0) {
+            printf("CARD: core1 did not start, relaunching (attempt %d)\n", attempt + 1);
+        }
+        watchdog_hw->scratch[3] += 1;
+        core1_alive = false;
+        multicore_reset_core1();
+        multicore_launch_func_core1(func);
+        for (int waited = 0; waited < 500 && !core1_alive; waited += 10) {
+            busy_wait_ms(10);
+        }
+    }
+    if (core1_alive) {
+        watchdog_hw->scratch[1] = 0;
+    }
+    return core1_alive;
+}
+#endif
 
 void card_start(uint8_t itf, void *(*func)(void *)) {
     timeout_start();
@@ -273,8 +356,17 @@ void card_start(uint8_t itf, void *(*func)(void *)) {
             card_exit();
         }
         if (func) {
+#if defined(PICO_PLATFORM)
+            if (!card_launch_verified(func)) {
+                chip_reset_bounded();
+                /* If the reset fired, unreachable. If it didn't (budget exhausted or the
+                 * AIRCR write failed), fall through and stay alive-dark: the host will
+                 * time out, which is honest. */
+            }
+#else
             multicore_reset_core1();
             multicore_launch_func_core1(func);
+#endif
         }
         led_set_mode(MODE_MOUNTED);
         card_locked_itf = itf;
@@ -344,8 +436,17 @@ int card_status(uint8_t itf) {
             if (m == EV_EXEC_FINISHED) {
                 timeout_stop();
                 led_set_mode(MODE_MOUNTED);
+#if defined(PICO_PLATFORM)
+                cmd_in_flight = false;
+                card_note_core1_alive();
+#endif
                 return PICOKEYS_OK;
             }
+#if defined(PICO_PLATFORM)
+            else if (m == EV_PING_ECHO) {
+                card_note_core1_alive();
+            }
+#endif
 #ifndef ENABLE_EMULATION
             else if (m == EV_PRESS_BUTTON) {
                 int ret = button_wait();
@@ -377,6 +478,88 @@ int card_status(uint8_t itf) {
     }
     return PICOKEYS_ERR_FILE_NOT_FOUND;
 }
+
+#if defined(PICO_PLATFORM)
+/* ---- Core1 dead-man's switch ----------------------------------------------------
+ * The launch-time check in card_start() catches a core1 that never starts, but core1
+ * can ALSO be lost mid-session (measured 2026-08-02 via SWD: core1 parked in a bootrom
+ * FIFO wait after it had been serving APDUs, core0 healthy, card mute). So: while a
+ * card function is active and NO command is in flight, ping core1 through the existing
+ * queue protocol (apdu_thread echoes any non-EV_CMD_AVAILABLE message back +1) and
+ * treat a missing echo as death. While a command IS in flight — an INITIALIZE wipe
+ * legitimately runs 60-90s+ — never probe; but a command outstanding beyond
+ * CMD_DEADLINE_MS is death too, since even the 180s commit cap bounds real work.
+ * Recovery is the same ladder as launch: relaunch, then bounded chip reset. */
+
+static void card_note_core1_alive(void) {
+    core1_last_ok_ms = board_millis();
+    ping_sent_ms = 0;
+}
+
+/* Recover a lost core1. Measured 2026-08-02: relaunching core1 alone is NOT enough —
+ * core0's CCID slot state (TPDU sequencing, block state) belongs to the dead session,
+ * so the card connects but every APDU transmit fails ("Transmit failed" at PC/SC).
+ * The only coherent recovery from a mid-session core1 death is a full chip reset:
+ * both sides reinitialise, the host re-enumerates and reconnects. */
+static void card_recover_core1(void) {
+    watchdog_hw->scratch[2] += 1;
+    printf("CARD: core1 lost mid-session, resetting chip\n");
+    cmd_in_flight = false;
+    ping_sent_ms = 0;
+    chip_reset_bounded();
+}
+
+void card_watchdog_task(void) {
+    uint64_t now = board_millis();
+    if (now - wd_last_run_ms < 50) {
+        return;
+    }
+    wd_last_run_ms = now;
+
+    if (card_locked_itf == ITF_TOTAL || card_locked_func == NULL) {
+        ping_sent_ms = 0;
+        cmd_in_flight = false;
+        return;
+    }
+
+    /* Consume anything core1 sent — every message is proof of life. The CCID layer
+     * does the same via card_status(); both run on core0, so whoever pops first wins
+     * and the handling is identical. */
+    uint32_t m = 0;
+    if (queue_try_remove(&card_to_usb_q, &m)) {
+        if (m == EV_PING_ECHO || m == EV_EXEC_FINISHED) {
+            cmd_in_flight = false;
+        }
+        else if (m == EV_RESET) {
+            usb_secure_reboot_now();
+        }
+        card_note_core1_alive();
+    }
+
+    if (cmd_in_flight) {
+        if (now - cmd_started_ms > CMD_DEADLINE_MS) {
+            printf("CARD: command outstanding >%lus — core1 presumed dead\n",
+                   (unsigned long) (CMD_DEADLINE_MS / 1000));
+            card_recover_core1();
+        }
+        return;
+    }
+
+    if (ping_sent_ms != 0) {
+        if (now - ping_sent_ms > CARD_PING_TIMEOUT_MS) {
+            card_recover_core1();
+        }
+        return;
+    }
+
+    if (now - core1_last_ok_ms > CARD_PING_INTERVAL_MS) {
+        uint32_t ping = EV_PING;
+        if (queue_try_add(&usb_to_card_q, &ping)) {
+            ping_sent_ms = now;
+        }
+    }
+}
+#endif
 
 #ifndef USB_ITF_CCID
 #include "device/usbd_pvt.h"

--- a/src/usb/usb.c
+++ b/src/usb/usb.c
@@ -248,8 +248,6 @@ bool is_busy(void) {
 
 #if defined(PICO_PLATFORM)
 /* State for the core1 dead-man's switch (card_watchdog_task(), bottom of file). */
-#define EV_PING                 0x10000u
-#define EV_PING_ECHO            (EV_PING + 1)
 #define CARD_PING_INTERVAL_MS   2000
 #define CARD_PING_TIMEOUT_MS    1000
 #define CMD_DEADLINE_MS         300000u   /* 180s commit cap + erase margin */

--- a/src/usb/usb.h
+++ b/src/usb/usb.h
@@ -96,6 +96,7 @@ extern volatile uint16_t finished_data_size;
 extern void usb_set_timeout_counter(uint8_t itf, uint32_t v);
 extern void card_init_core1(void);
 extern void card_watchdog_task(void);
+extern void schedule_chip_reset(uint32_t delay_ms);
 
 extern void usb_send_event(uint32_t flag);
 extern void timeout_stop(void);

--- a/src/usb/usb.h
+++ b/src/usb/usb.h
@@ -95,6 +95,7 @@ extern void usb_init(void);
 extern volatile uint16_t finished_data_size;
 extern void usb_set_timeout_counter(uint8_t itf, uint32_t v);
 extern void card_init_core1(void);
+extern void card_watchdog_task(void);
 
 extern void usb_send_event(uint32_t flag);
 extern void timeout_stop(void);

--- a/src/usb/usb.h
+++ b/src/usb/usb.h
@@ -51,6 +51,11 @@
 #define EV_BUTTON_PRESSED        32
 #define EV_BUTTON_CANCELLED      64
 
+/* Dead-man's switch probe (card_watchdog_task): apdu_thread must echo this and
+ * CONTINUE the loop — never process it as a command (see apdu.c). */
+#define EV_PING                 0x10000u
+#define EV_PING_ECHO            (EV_PING + 1)
+
 enum { ITF_INVALID = 0xFF };
 
 #ifdef USB_ITF_HID


### PR DESCRIPTION
Closes #25

## Why (context)

We use the Pico HSM as a **staging / procedure-rehearsal device** for a hardware-rooted
key-custody project whose production tokens are Nitrokey HSM 2s (genuine SmartCard-HSMs). The
Pico is deliberately *not* the main HSM; it exists so that wipe-and-reprovision drills ("any
card can die and be replaced from the seed") can run end-to-end without touching production
hardware. That drill workload — INITIALIZE DEVICE in a loop, DKEK domain create, share import,
wrapped-key unwrap — exercises the reset path and the flash layer far harder than everyday
card use, and it measured out a family of reliability defects on RP2350B. This PR is the
minimal set of changes that makes that loop reliable, each validated on hardware with SWD
forensics (Debug Probe + OpenOCD `rp2350` target).

## What it changes

**Reset path**
- `cmd_initialize.c` — after re-personalisation, schedule a chip reset instead of leaving the
  card stateless (the response is transmitted first; a reset executed inside the handler lands
  before it — measured as `Transmit failed` on the host).
- `main.c` — arm `POWMAN_WDSEL.RESET_SWCORE|RESET_PSM|RESET_POWMAN_ASYNC` (+ PSM_WDSEL
  all-ones) at every boot, so every watchdog-family reset power-cycles the switched core
  domain ("same effect as a power-on reset", RP2350 datasheet). Fixes the ~5–10% of warm
  resets that never started the cores. **100/100 consecutive reboots validated.**
- Scheduled (post-wipe) resets use the bootrom's `rom_reboot()` with the deep bits cleared —
  the combination measured best for post-INITIALIZE boots (22/23 recovery cycles); recovery
  resets use the deep watchdog path (100/100 hammered). `AIRCR.SYSRESETREQ` is avoided: on
  RP2040/RP2350 it resets only the asserting core (raspberrypi/pico-feedback#329).
- A scheduled reset never fires while the flash layer has lazy writes queued (drain guard) —
  a reset landing mid-drain leaves a half-written file system.

**Core1 liveness**
- `usb.c` — `card_start()` verifies core1 actually entered (the SDK's FIFO launch handshake
  can complete against stale data while core1 stays parked in the bootrom — caught live via
  SWD), retries, and escalates to a bounded chip reset (budget in watchdog scratch, never a
  reset loop).
- A dead-man's switch pings core1 through the existing queue echo protocol while a card
  function is active and idle; a missing echo — or a command outstanding past a bound —
  recovers via bounded chip reset. (Includes the fix for the probe itself re-executing staged
  APDUs.)

**Flash layer (defensive, not the root fix)**
- `low_flash.c` — queued page addresses are validated against the **real** fs data region
  (`flash_addr_in_fs()`; the region is partition-dependent — hardcoding `FLASH_SIZE_BYTES>>1`
  is wrong on partition-table builds) before erase/program; a corrupt entry previously reached
  `hard_assert` and bricked the device.
- `hard_assertion_failure()` overridden: reboot via `rom_reboot` instead of
  panic → bkpt → `_exit` (measured: device catatonic for a day, needing a replug).
- Multicore lockout start/end timeouts 1 ms → 100 ms with an explicit re-sync: a timed-out
  END orphaned core1 in the lockout victim handler permanently (caught live).

## Validation

- 100/100 rapid reboots (rescue-APDU reboot loop) on the deep-reset build.
- 22/23 full wipe → DKEK import → key import → sign → verify cycles recovered, on hardware.
- Failure forensics throughout this work were register-level (SWD): watchdog REASON, core
  PCs/backtraces, BFAR/CFSR, POWMAN/PSM dumps — no guessed fixes.

## Explicitly NOT in this PR

The flash **persistence** defect (see the linked issue, Bug 6): fs metadata corruption
(zero-KCV symptom), `unwrapKey` `SW=6400` despite matching KCVs, initialize writes lost across
reset, and a `find_free_page` HardFault on a garbage `prev_addr` (`BFAR=0x6CB44000`). The
guards here contain it; they do not fix it. We believe that needs a review of the
page-cache/lazy-drain design in `low_flash.c`/`flash.c`, and we're glad to test patches.
