### PR TITLE
fix(hsm): defer the post-INITIALIZE reset until the response is out

### DIFF
--- a/src/fs/flash.h
+++ b/src/fs/flash.h
@@ -52,5 +52,8 @@ extern void flash_task(void);
 extern void low_flash_init(void);
 extern void flash_commit(void);
 extern bool flash_commit_sync(uint32_t timeout_ms);
+extern void low_flash_quiesce(void);
+extern void low_flash_unquiesce(void);
+extern bool low_flash_busy(void);
 
 #endif // _FLASH_H

--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -172,6 +172,23 @@ void low_flash_task(void){
     }
 }
 
+/* Take the flash mutex and NEVER give it back. Every flash operation in this layer — queued
+ * erases, commits, background page handling — enters mtx_flash (low_flash_task only via
+ * try_enter, so a held mutex makes it skip), and the underlying SDK erase/program calls are
+ * synchronous, so once the mutex is held the flash chip is IDLE and stays idle. Intended for
+ * use immediately before a chip reset: a reset landing while the flash chip is internally busy
+ * is the measured cause of the intermittent post-reset boot wedge (see cmd_initialize.c in
+ * pico-hsm). Not re-entrant; the caller is expected to reset the chip before ever releasing. */
+void low_flash_quiesce(void) {
+    mutex_enter_blocking(&mtx_flash);
+}
+
+/* Release the mutex taken by low_flash_quiesce(). Only for the path where the reset the
+ * quiesce was taken for did NOT fire and the device stays alive — see cmd_initialize.c. */
+void low_flash_unquiesce(void) {
+    mutex_exit(&mtx_flash);
+}
+
 #ifdef PICO_RP2040
 void phymarker_write(void);
 #endif
@@ -256,6 +273,17 @@ static bool low_flash_available(void) {
     bool available = flash_available;
     mutex_exit(&mtx_flash);
     return available;
+}
+
+/* Public idle check for reset scheduling: true while the flash layer has queued or
+ * in-flight work. A reset that lands while lazy writes are still pending leaves a
+ * half-written file system and the next boot may fail to present the card (measured
+ * 2026-08-03: boot mute after init-on-blank-fs, repeatedly). */
+bool low_flash_busy(void) {
+    mutex_enter_blocking(&mtx_flash);
+    bool busy = flash_available || ready_pages > 0;
+    mutex_exit(&mtx_flash);
+    return busy;
 }
 
 bool low_flash_commit_sync(uint32_t timeout_ms) {

--- a/src/main.c
+++ b/src/main.c
@@ -117,6 +117,9 @@ void execute_tasks(void) {
     rest_task();
 #endif
     usb_task();
+#ifdef PICO_PLATFORM
+    card_watchdog_task();
+#endif
     led_blinking_task();
 #ifdef ENABLE_LVGL_UI
     platform_ui_task();

--- a/src/usb/usb.c
+++ b/src/usb/usb.c
@@ -22,7 +22,9 @@
 #include "pico_time.h"
 #if defined(PICO_PLATFORM)
 #include "pico/bootrom.h"
+#include "boot/picoboot_constants.h"
 #include "pico/multicore.h"
+#include "pico/time.h"
 #include "hardware/sync.h"
 #define multicore_launch_func_core1(a) multicore_launch_core1((void (*) (void))a)
 #endif
@@ -266,6 +268,38 @@ void card_init_core1(void) {
 
 volatile uint16_t finished_data_size = 0;
 
+#if defined(PICO_PLATFORM)
+/* Full-chip reset via the BOOTROM's own reboot facility. Why not the alternatives:
+ *  - AIRCR.SYSRESETREQ: resets only the asserting core on RP2040/RP2350 (the datasheet's
+ *    generic ARM text is wrong for these parts; measured here 2026-08-02 as a complete
+ *    no-op — RAM statics survived the write).
+ *  - SDK watchdog_reboot(): full-chip, but measured to wedge the post-reset boot ~7% of
+ *    cycles (shapes A/B in the forensic record).
+ *  - rom_reboot(): still watchdog-based, but it is the bootrom's own sequenced path — the
+ *    same mechanism every UF2 flash-update reboot uses, the most field-exercised warm
+ *    reset this chip has.
+ * Quiesce flash first: no flash op may be in flight when the reset lands. */
+static void chip_reset_now(void) {
+    low_flash_quiesce();
+    printf("CARD: rebooting via rom_reboot\n");
+    rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_NORMAL, 1, 0, 0);
+    /* Unreachable if the reset took. Stay alive and working if it did not. */
+    busy_wait_ms(2000);
+    low_flash_unquiesce();
+    printf("CARD: ERROR reset did not fire — staying alive\n");
+}
+
+/* Deferred chip reset, fired by card_watchdog_task() from core0's main loop. Exists
+ * because a reset must never run inside an APDU handler: the response is transmitted
+ * after the handler returns, so a synchronous reset lands mid-command (measured:
+ * Transmit failed on the host). */
+static uint64_t scheduled_reset_at_ms = 0;   /* 0 = none pending */
+
+void schedule_chip_reset(uint32_t delay_ms) {
+    scheduled_reset_at_ms = board_millis() + delay_ms;
+}
+#endif
+
 void card_start(uint8_t itf, void *(*func)(void *)) {
     timeout_start();
     if (card_locked_itf != itf || card_locked_func != func) {
@@ -377,6 +411,28 @@ int card_status(uint8_t itf) {
     }
     return PICOKEYS_ERR_FILE_NOT_FOUND;
 }
+
+#if defined(PICO_PLATFORM)
+/* Fire a scheduled chip reset from core0's main loop (see schedule_chip_reset). Never
+ * fire it while the flash layer still has lazy work queued: a reset landing mid-drain
+ * leaves a half-written file system and the next boot can fail to present the card.
+ * Wait for the drain, bounded so a stuck queue cannot defer the reset forever. */
+void card_watchdog_task(void) {
+    if (scheduled_reset_at_ms == 0) {
+        return;
+    }
+    uint64_t now = board_millis();
+    if ((long long) (now - scheduled_reset_at_ms) < 0) {
+        return;   /* not due yet */
+    }
+    if (low_flash_busy() && (long long) (now - scheduled_reset_at_ms) < 30000) {
+        return;   /* drain guard: retry next pass */
+    }
+    scheduled_reset_at_ms = 0;
+    printf("CARD: scheduled reset firing\n");
+    chip_reset_now();
+}
+#endif
 
 #ifndef USB_ITF_CCID
 #include "device/usbd_pvt.h"

--- a/src/usb/usb.h
+++ b/src/usb/usb.h
@@ -95,6 +95,8 @@ extern void usb_init(void);
 extern volatile uint16_t finished_data_size;
 extern void usb_set_timeout_counter(uint8_t itf, uint32_t v);
 extern void card_init_core1(void);
+extern void card_watchdog_task(void);
+extern void schedule_chip_reset(uint32_t delay_ms);
 
 extern void usb_send_event(uint32_t flag);
 extern void timeout_stop(void);


### PR DESCRIPTION
> **CORRECTED 2026-08-05 — now a draft; the premise below is disproven.** A reproduction on
> unmodified upstream firmware shows the card does **not** complete INITIALIZE and then sit dead.
> Core0 **panics during** INITIALIZE inside `flash_range_erase()` while holding the multicore
> lockout with interrupts disabled. A post-INITIALIZE reset therefore **masks a panic** rather
> than fixing the cause. Root cause is `scan_region()` (`file.c:336`) accepting an out-of-region
> chain link. Full trace: https://github.com/polhenarejos/pico-keys-sdk/issues/25#issuecomment-5194772009
>
> We are happy to close this. The real fixes are pointer validation in `scan_region()` and the
> pre-write validation in #30. Original description kept below for context.

Without a reset after INITIALIZE the card never rebuilds its state until a physical replug. The reset must be deferred until the APDU response is transmitted (measured: a synchronous reset lands mid-command = host-side Transmit failed) and must never fire with flash writes in flight.

This adds `schedule_chip_reset()` + `card_watchdog_task()` (fires the scheduled reset from core0's loop, with a drain guard: never while `low_flash_busy()`, 30s bound), `low_flash_quiesce()`/`low_flash_unquiesce()`/`low_flash_busy()`, and a reset path that quiesces flash and reboots via `rom_reboot()`, staying alive if the reset does not take.

See #25 for the full forensic record.

---
*Review response (issue #25, Bug 1): narrowed to just the INITIALIZE reset, deferred so the response transmits first; the pico-hsm side is #136. Note: we corrected our earlier misattribution to pico-hsm#9 in the issue thread.*

