### PR TITLE
fix(flash): raise lockout timeouts, abort the drain pass on end-timeout

### DIFF
--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -113,7 +113,7 @@ void low_flash_task(void){
                 if (flash_pages[r].ready == true) {
 #if defined(PICO_PLATFORM) || defined(ESP_PLATFORM)
                     //printf("WRITTING %X\n",flash_pages[r].address-XIP_BASE);
-                    if (multicore_lockout_start_timeout_us(1000) == false) {
+                    if (multicore_lockout_start_timeout_us(100000) == false) {
                         printf("WARN: FLASH LOCKOUT START TIMEOUT\n");
                         continue;
                     }
@@ -122,9 +122,18 @@ void low_flash_task(void){
                     flash_range_erase(flash_pages[r].address - XIP_BASE, FLASH_SECTOR_SIZE);
                     flash_range_program(flash_pages[r].address - XIP_BASE, flash_pages[r].page, FLASH_SECTOR_SIZE);
                     restore_interrupts(ints);
-                    if (multicore_lockout_end_timeout_us(1000) == false) {
-                        printf("WARN: FLASH LOCKOUT END TIMEOUT\n");
-                        continue;
+                    if (multicore_lockout_end_timeout_us(100000) == false) {
+                        /* DEFENSIVE ONLY — this timeout has never been observed to fire.
+                         * The core1-parked-in-multicore_lockout_handler state originally
+                         * measured (2026-08-02) is NOT caused by an END timeout: core0
+                         * panics between lockout START and END (and after
+                         * save_and_disable_interrupts()), so the lockout is never released
+                         * (reproduced on unmodified upstream firmware 2026-08-05). The
+                         * 100 ms bound is kept only so a genuine race cannot block forever. Do NOT re-enter the lockout to re-sync — the SDK
+                         * documents lockouts as non-nestable. Stop this drain pass; the
+                         * page stays queued and the next pass retries. */
+                        printf("ERROR: FLASH LOCKOUT END TIMEOUT — aborting this drain pass\n");
+                        break;
                     }
                     //printf("WRITEN %X !\n",flash_pages[r].address);
 #else
@@ -135,7 +144,7 @@ void low_flash_task(void){
                 }
                 else if (flash_pages[r].erase == true) {
 #if defined(PICO_PLATFORM) || defined(ESP_PLATFORM)
-                    if (multicore_lockout_start_timeout_us(1000) == false) {
+                    if (multicore_lockout_start_timeout_us(100000) == false) {
                         printf("WARN: FLASH LOCKOUT START TIMEOUT\n");
                         continue;
                     }
@@ -143,9 +152,18 @@ void low_flash_task(void){
                     uint32_t ints = save_and_disable_interrupts();
                     flash_range_erase(flash_pages[r].address - XIP_BASE, flash_pages[r].page_size ? ((int) (flash_pages[r].page_size / FLASH_SECTOR_SIZE)) * FLASH_SECTOR_SIZE : FLASH_SECTOR_SIZE);
                     restore_interrupts(ints);
-                    if (multicore_lockout_end_timeout_us(1000) == false) {
-                        printf("WARN: FLASH LOCKOUT END TIMEOUT\n");
-                        continue;
+                    if (multicore_lockout_end_timeout_us(100000) == false) {
+                        /* DEFENSIVE ONLY — this timeout has never been observed to fire.
+                         * The core1-parked-in-multicore_lockout_handler state originally
+                         * measured (2026-08-02) is NOT caused by an END timeout: core0
+                         * panics between lockout START and END (and after
+                         * save_and_disable_interrupts()), so the lockout is never released
+                         * (reproduced on unmodified upstream firmware 2026-08-05). The
+                         * 100 ms bound is kept only so a genuine race cannot block forever. Do NOT re-enter the lockout to re-sync — the SDK
+                         * documents lockouts as non-nestable. Stop this drain pass; the
+                         * page stays queued and the next pass retries. */
+                        printf("ERROR: FLASH LOCKOUT END TIMEOUT — aborting this drain pass\n");
+                        break;
                     }
 #else
                     memset(map + flash_pages[r].address, 0, FLASH_SECTOR_SIZE);


### PR DESCRIPTION
> **CORRECTED 2026-08-05 — now a draft; scenario never observed.** You asked whether the
> END-timeout warning was ever actually captured. **It was not.** The reproduction on unmodified
> firmware shows core1 is orphaned because core0 **panics between lockout START and END**, not
> because either call timed out. This PR is therefore defensive hardening against a case we have
> never measured — treat it accordingly, and we will close it if you prefer. Details: https://github.com/polhenarejos/pico-keys-sdk/issues/25#issuecomment-5194772009
>
> Concurrency audit you asked for: the only in-tree lockout callers are `low_flash.c:116/125/138/146`,
> all inside `low_flash_task()`'s drain loop on core0, plus `multicore_lockout_victim_init()` at
> `:243`. `phymarker_write()` erases/programs without the lockout but is `#ifdef PICO_RP2040` and
> runs from `low_flash_init()` before core1 launches — not a concurrency hazard.

Measured via SWD: a timed-out 1ms lockout END orphaned core1 in the lockout victim handler (`multicore_lockout_handler`) permanently — card mute. The 1ms default was far inside normal IRQ/entry latency.

Raise the lockout start/end timeouts to 100ms and abort the drain pass on an end-timeout (the page stays queued; the next pass retries). No re-sync by re-entering the lockout: lockouts are non-nestable.

See #25 for the full forensic record.

---
*Review response (issue #25, Bug 4): the re-sync pair was removed (lockouts are non-nestable — agreed); on end-timeout the drain pass aborts loudly.*

