### PR TITLE
fix(flash): validate addresses against the real fs bounds before any read or erase

### DIFF
--- a/src/fs/flash.c
+++ b/src/fs/flash.c
@@ -66,6 +66,25 @@ bool flash_addr_in_fs(uintptr_t addr) {
     return addr >= start_data_pool && addr < end_flash;
 }
 
+/* True only if the WHOLE [addr, addr + len) span stays inside the fs data region —
+ * and so does the sector-aligned base that find_free_page() will actually operate on.
+ * Checking just the start address is not enough: flash_program_block() walks forward
+ * across sectors as it consumes data, and flash_erase_page() erases page_size bytes,
+ * so a start address one byte inside the region can still run off the end. The
+ * subtraction is done only after addr is known to be below end_flash, so it cannot wrap. */
+bool flash_range_in_fs(uintptr_t addr, size_t len) {
+    if (len == 0) {
+        return false;
+    }
+    if (addr < start_data_pool || addr >= end_flash) {
+        return false;
+    }
+    if ((addr & ~(uintptr_t) (FLASH_SECTOR_SIZE - 1)) < start_data_pool) {
+        return false;
+    }
+    return len <= (size_t) (end_flash - addr);
+}
+
 void flash_set_bounds(uintptr_t start, uintptr_t end) {
     end_flash = end;
     end_rom_pool = end_flash - FLASH_DATA_HEADER_SIZE - 4;

--- a/src/fs/flash.c
+++ b/src/fs/flash.c
@@ -57,6 +57,15 @@ uintptr_t end_flash, end_rom_pool, start_rom_pool, end_data_pool, start_data_poo
 uintptr_t last_base;
 uint32_t num_files = 0;
 
+/* True if addr is inside the fs data region [start_data_pool, end_flash). Used by
+ * low_flash.c's corrupt-page guard — the region is partition-dependent (measured
+ * 2026-08-04: ~[1MB, 4MB) on this build, NOT [8MB, 16MB) as a hardcoded
+ * FLASH_SIZE_BYTES>>1 bound wrongly assumed, which made the guard drop every
+ * legitimate lazy write). */
+bool flash_addr_in_fs(uintptr_t addr) {
+    return addr >= start_data_pool && addr < end_flash;
+}
+
 void flash_set_bounds(uintptr_t start, uintptr_t end) {
     end_flash = end;
     end_rom_pool = end_flash - FLASH_DATA_HEADER_SIZE - 4;

--- a/src/fs/flash.h
+++ b/src/fs/flash.h
@@ -35,6 +35,7 @@ extern uint32_t flash_size(void);
 
 extern void flash_set_bounds(uintptr_t start, uintptr_t end);
 extern bool flash_addr_in_fs(uintptr_t addr);
+extern bool flash_range_in_fs(uintptr_t addr, size_t len);
 extern int flash_write_data_to_file(file_t *file, const_byte_array_t data);
 extern int flash_write_data_to_file_offset(file_t *file, const_byte_array_t data, uint32_t offset);
 extern int flash_program_block(uintptr_t addr, const_byte_array_t data);

--- a/src/fs/flash.h
+++ b/src/fs/flash.h
@@ -34,6 +34,7 @@ extern uint32_t flash_num_files(void);
 extern uint32_t flash_size(void);
 
 extern void flash_set_bounds(uintptr_t start, uintptr_t end);
+extern bool flash_addr_in_fs(uintptr_t addr);
 extern int flash_write_data_to_file(file_t *file, const_byte_array_t data);
 extern int flash_write_data_to_file_offset(file_t *file, const_byte_array_t data, uint32_t offset);
 extern int flash_program_block(uintptr_t addr, const_byte_array_t data);

--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -326,8 +326,9 @@ int flash_program_block(uintptr_t addr, const_byte_array_t data) {
     /* Validate BEFORE find_free_page() reads from the address: fs metadata corruption
      * can hand us a garbage pointer (measured 2026-08-04: BFAR=0x6CB44000, a bogus
      * prev_addr reached via flash_clear_file -> HardFault). Fail loudly, never read. */
-    if (!flash_addr_in_fs(addr)) {
-        printf("ERROR: flash_program_block to out-of-fs address %p — refusing\n", (void *) addr);
+    if (!flash_range_in_fs(addr, data.len)) {
+        printf("ERROR: flash_program_block %p+%u out of fs region — refusing\n",
+               (void *) addr, (unsigned) data.len);
         return PICOKEYS_ERR_MEMORY_FATAL;
     }
 
@@ -466,8 +467,17 @@ uint8_t flash_read_uint8(uintptr_t addr) {
 int flash_erase_page(uintptr_t addr, size_t page_size) {
     page_flash_t *p = NULL;
 
-    if (!flash_addr_in_fs(addr)) {
-        printf("ERROR: flash_erase_page of out-of-fs address %p — refusing\n", (void *) addr);
+    /* Validate the full erase SPAN: low_flash_task() erases page_size rounded down to
+     * whole sectors (minimum one), so a start address inside the region can still
+     * erase past its end. */
+    size_t erase_len = page_size ? (page_size / FLASH_SECTOR_SIZE) * FLASH_SECTOR_SIZE
+                                 : FLASH_SECTOR_SIZE;
+    if (erase_len == 0) {
+        erase_len = FLASH_SECTOR_SIZE;
+    }
+    if (!flash_range_in_fs(addr, erase_len)) {
+        printf("ERROR: flash_erase_page %p+%u out of fs region — refusing\n",
+               (void *) addr, (unsigned) erase_len);
         return PICOKEYS_ERR_MEMORY_FATAL;
     }
     mutex_enter_blocking(&mtx_flash);

--- a/src/fs/low_flash.c
+++ b/src/fs/low_flash.c
@@ -323,6 +323,13 @@ int flash_program_block(uintptr_t addr, const_byte_array_t data) {
     if (!data.data || data.len == 0) {
         return PICOKEYS_ERR_NULL_PARAM;
     }
+    /* Validate BEFORE find_free_page() reads from the address: fs metadata corruption
+     * can hand us a garbage pointer (measured 2026-08-04: BFAR=0x6CB44000, a bogus
+     * prev_addr reached via flash_clear_file -> HardFault). Fail loudly, never read. */
+    if (!flash_addr_in_fs(addr)) {
+        printf("ERROR: flash_program_block to out-of-fs address %p — refusing\n", (void *) addr);
+        return PICOKEYS_ERR_MEMORY_FATAL;
+    }
 
     while (data.len > 0) {
         size_t page_offset = addr & (FLASH_SECTOR_SIZE - 1);
@@ -459,6 +466,10 @@ uint8_t flash_read_uint8(uintptr_t addr) {
 int flash_erase_page(uintptr_t addr, size_t page_size) {
     page_flash_t *p = NULL;
 
+    if (!flash_addr_in_fs(addr)) {
+        printf("ERROR: flash_erase_page of out-of-fs address %p — refusing\n", (void *) addr);
+        return PICOKEYS_ERR_MEMORY_FATAL;
+    }
     mutex_enter_blocking(&mtx_flash);
     if (ready_pages == TOTAL_FLASH_PAGES) {
         mutex_exit(&mtx_flash);


### PR DESCRIPTION
> **Strengthened 2026-08-05 — now demonstrated on unmodified upstream firmware.** The original
> description below cites a HardFault via `flash_clear_file`. A clean-room reproduction
> (`pico-hsm 1ad8444` + `pico-keys-sdk 843a3dc`, no patches, after a full 16 MB erase) reached the
> same class of failure by a **different and more direct route**, confirming this guard is needed
> upstream and is not patch-induced:
>
> ```
> scan_region() (file.c:336) accepts a chain link with only 'base >= startp'
>   -> base = 0x2000D59B (SRAM, odd-aligned) accepted as a record base
>   -> file->data = base + 10 = 0x2000D5A5
>   -> cmd_update_ef -> file_put_data -> flash_write_data_to_file_internal (flash.c:195)
>   -> flash_program_halfword(0x2000D5A5) -> find_free_page() caches 4KB from SRAM, ready=1
>   -> low_flash_task() -> flash_range_erase(0x1000D000, 4096)
>   -> hard_assert(flash_offs + count <= PICO_FLASH_SIZE_BYTES) fires, core0 dies holding the lockout
> ```
>
> **This guard is a safety net, not the fix** — it converts the panic into a clean error return
> while `file->data` still points at SRAM. The root fix is the `scan_flash()`/`scan_region()`
> pointer validation you proposed. Full trace: https://github.com/polhenarejos/pico-keys-sdk/issues/25#issuecomment-5194772009
>
> **Hardware scope:** single RP2350B board; RP2040 compile-only, never run.

Measured: corrupted fs metadata handed `find_free_page()` a garbage address (BFAR=0x6CB44000, a bogus prev_addr reached via `flash_clear_file`) → HardFault.

Add `flash_addr_in_fs()` checking against the real fs bounds (partition-table-derived [start_data_pool, end_flash), NOT FLASH_SIZE/2) and refuse out-of-fs addresses in `flash_program_block()` and `flash_erase_page()` with `PICOKEYS_ERR_MEMORY_FATAL` before `find_free_page()` is reached.

See #25 for the full forensic record.

---
*Review response (issue #25, Bug 5): validation now happens BEFORE the first read, returns PICOKEYS_ERR_MEMORY_FATAL instead of silently dropping, and covers erase as well as program. The panic-recovery policy is withdrawn from this PR series per review.*

