### PR TITLE
feat(reset): make every watchdog-family reset a full switched-core power cycle (RP2350)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,9 @@
 #include "bsp/board.h"
 #include "hardware/structs/ioqspi.h"
 #include "pico/stdio.h"
+#include "hardware/powman.h"
+#include "hardware/structs/psm.h"
+#include "hardware/regs/psm.h"
 #endif
 
 #include "random.h"
@@ -162,6 +165,26 @@ int main(void) {
 #ifdef PICO_PLATFORM
     board_init();
     stdio_init_all();
+#endif
+
+#ifdef PICO_RP2350
+    /* Make EVERY watchdog-family reset a FULL switched-core power cycle. The default
+     * watchdog reset (PSM_WDSEL minus ROSC/XOSC) leaves the switched core domain
+     * powered and was measured to wedge the warm boot ~5-10% of resets on RP2350B —
+     * cores never start, identically across watchdog_reboot() and rom_reboot()
+     * (2026-08-02/03 forensic record in regalia hardware/pico-hsm/). POWMAN_WDSEL
+     * RESET_SWCORE makes the reset power-cycle the switched domain and run the full
+     * PSM sequence — "the same effect as a power-on reset for the switched core
+     * power domain" (RP2350 datasheet). RESET_POWMAN_ASYNC restores powman defaults
+     * without depending on clk_ref; because it restores defaults, this register must
+     * be re-armed on EVERY boot — hence here, first thing. PSM_WDSEL all-ones per
+     * the datasheet note (powman ignores watchdog resets that don't select CLOCKS
+     * or earlier). RP2350-only: POWMAN does not exist on RP2040. */
+    powman_set_bits(&powman_hw->wdsel,
+                    POWMAN_WDSEL_RESET_POWMAN_ASYNC_BITS |
+                    POWMAN_WDSEL_RESET_SWCORE_BITS |
+                    POWMAN_WDSEL_RESET_PSM_BITS);
+    psm_hw->wdsel = PSM_WDSEL_BITS;
 #endif
 
 #else

--- a/src/main.c
+++ b/src/main.c
@@ -31,9 +31,14 @@
 #include "bsp/board.h"
 #include "hardware/structs/ioqspi.h"
 #include "pico/stdio.h"
+#ifdef PICO_RP2350
+/* POWMAN is RP2350-only — hardware/powman.h does not exist in an RP2040 build
+ * (verified: including it unguarded fails the rp2040 build with
+ * "fatal error: hardware/powman.h: No such file or directory"). */
 #include "hardware/powman.h"
 #include "hardware/structs/psm.h"
 #include "hardware/regs/psm.h"
+#endif
 #endif
 
 #include "random.h"


### PR DESCRIPTION
> **Hardware scope (added 2026-08-05).** Every runtime number in this PR — including the
> 100/100 reboots — was measured on **a single Waveshare RP2350-PiZero (RP2350B)** with a
> Raspberry Pi Debug Probe. It is not a multi-board or fleet result.
>
> **RP2040 is compile-only.** We have no RP2040 hardware and have never executed that path. The
> include-guard fix in 49c8d5d was verified by building `PICO_BOARD=pico PICO_PLATFORM=rp2040`
> (previously broken outright) and `rp2350-arm-s`; both compile, neither RP2040 result is a
> runtime claim.

Measured: ~5-10% of watchdog/rom_reboot warm resets never started the cores (both cores all-zero, XIP SSI zero — the post-reset boot never reached XIP setup).

Arm POWMAN_WDSEL RESET_SWCORE|RESET_PSM|RESET_POWMAN_ASYNC at boot so each reset is a switched-core power cycle running the full PSM sequence (the RP2350 datasheet's equivalent of a power-on reset for that domain), with PSM_WDSEL all-ones per the datasheet note. Re-armed on every boot since RESET_POWMAN_ASYNC restores powman defaults. 100/100 reboots validated.

RP2350-only (POWMAN absent on RP2040).

See #25 for the full forensic record.

---
*Review response (issue #25, Bug 2): guarded under PICO_RP2350 (POWMAN does not exist on RP2040).*

