### PR TITLE
fix(fs): never write a FILE_DATA_FUNC file's ->data — it is a function pointer, not a flash address

### DIFF
--- a/src/fs/flash.c
+++ b/src/fs/flash.c
@@ -181,9 +181,17 @@ static int flash_write_data_to_file_internal(file_t *file, const_byte_array_t da
     /* A FILE_DATA_FUNC file's ->data is a generator FUNCTION POINTER, not a flash
      * address. The SELECT/FCI path (file.c) and the READ path (cmd_read_binary.c)
      * both check this flag before using ->data; this write path did not, so an
-     * UPDATE BINARY on such an EF handed a .text address to the flash layer. */
+     * UPDATE BINARY on such an EF handed a .text address to the flash layer.
+     *
+     * Accept and discard rather than returning an error. Returning an error is not
+     * viable in practice: the Smart Card Shell's SmartCardHSM.js aborts initialisation
+     * with "GPError ... Unexpected SW1/SW2=6581" as soon as a write to one of these EFs
+     * is refused, so scsh-driven provisioning cannot complete. (OpenSC ignores the same
+     * failure, which is why it only shows up under scsh.) The content of these EFs is
+     * regenerated from live card state on every read, so discarding the host's copy
+     * loses nothing structural. */
     if ((file_get_type(file) & FILE_DATA_FUNC) == FILE_DATA_FUNC) {
-        return PICOKEYS_ERR_BLOCKED;
+        return PICOKEYS_OK;
     }
 
     len = (uint32_t)data.len;

--- a/src/fs/flash.c
+++ b/src/fs/flash.c
@@ -178,6 +178,14 @@ static int flash_write_data_to_file_internal(file_t *file, const_byte_array_t da
         return PICOKEYS_ERR_NULL_PARAM;
     }
 
+    /* A FILE_DATA_FUNC file's ->data is a generator FUNCTION POINTER, not a flash
+     * address. The SELECT/FCI path (file.c) and the READ path (cmd_read_binary.c)
+     * both check this flag before using ->data; this write path did not, so an
+     * UPDATE BINARY on such an EF handed a .text address to the flash layer. */
+    if ((file_get_type(file) & FILE_DATA_FUNC) == FILE_DATA_FUNC) {
+        return PICOKEYS_ERR_BLOCKED;
+    }
+
     len = (uint32_t)data.len;
 
     uint32_t old_size = file_get_size(file);


### PR DESCRIPTION
Fixes the root cause of the mute-card-after-INITIALIZE failure reported in #25.

## The bug

`flash_write_data_to_file_internal()` uses `file->data` as a flash address after checking only
that it is non-NULL. For a `FILE_DATA_FUNC` file, `->data` is a **generator function pointer**,
not a flash address.

Every other consumer already checks the flag before using `->data`:

* `file.c` (SELECT / FCI): `if ((type & FILE_DATA_FUNC) == FILE_DATA_FUNC) { call it }`
* `cmd_read_binary.c:137` (READ): same check, calls the handler

The write path did not, so an `UPDATE BINARY` on such an EF hands a `.text` address to the
flash layer.

## How it is reached in practice

`pico-hsm` declares EF.TokenInfo (`0x2F03`) as
`FILE_TYPE_WORKING_EF | FILE_DATA_FUNC` with `.data = (uint8_t *) parse_token_info`, and
OpenSC's `sc_hsm_initialize` writes EF.TokenInfo as part of INITIALIZE
(`CLA:0 INS:D7 P1:2F P2:03`). So an ordinary, spec-conformant provisioning run triggers it.

Captured on unmodified upstream firmware over SWD:

```
(gdb) info symbol ((file_t*)0x20056b24)->data
parse_token_info + 1 in section .text        <- Thumb function pointer, fid=0x2f03

#0 find_free_page (addr=0x2000D5A5)                      low_flash.c:316
#1 flash_program_block (addr=0x2000D5A5, data={len=2})   low_flash.c:333
#2 flash_program_halfword (data@entry=17)                low_flash.c:354
#3 flash_write_data_to_file_internal (file=<file_entries+80>)  flash.c:195
#6 cmd_update_ef ()                            src/hsm/cmd_update_ef.c:134
```

`find_free_page()` then caches 4 KB of `.text` as a dirty sector and `low_flash_task()` calls
`flash_range_erase(0x2000D000 - XIP_BASE, 4096)`, tripping
`hard_assert(flash_offs + count <= PICO_FLASH_SIZE_BYTES)`.

The panic lands between `multicore_lockout_start_timeout_us()` and `..._end_timeout_us()` and
after `save_and_disable_interrupts()`, so core0 dies holding the lockout with interrupts
disabled and core1 stays parked in `multicore_lockout_handler`. The reader remains enumerated
and the card never answers again until a full boot.

## It is deterministic

`file_get_size()` does `file_read_uint16(tf->data)`, which for one of these files reads the
first halfword of the function's own machine code as the file size:

```
2000d5a4 <parse_token_info>:  01 29 01 d0 2c 20 70 47   ->  old_size = 0x2901 = 10497
```

A 17-byte TokenInfo write therefore always satisfies
`len <= old_size && len < FLASH_FILE_EXTENDED_LENGTH` and always takes the in-place branch.
No race, no state dependence.

## Minimal reproduction (two APDUs, no INITIALIZE needed)

```
00 20 00 88 08 <SO-PIN>                 VERIFY SO-PIN            -> 9000
00 D7 2F 03 13 53 11 00*17              UPDATE BINARY EF 2F03
```

* stock: card goes mute permanently
* with this patch: `6581`, card keeps working

(The VERIFY is required because the EF's ACL gates `ACL_OP_UPDATE_ERASE`; unauthenticated the
command is refused with `6982` before reaching the write.)

## Isolation test

This 8-line change applied to otherwise-stock firmware (`pico-hsm 1ad8444` +
`pico-keys-sdk 843a3dc`, nothing else changed), full 16 MB erase before each:

| firmware | INITIALIZE runs | result |
|---|---|---|
| stock | 2 | mute on the 2nd, permanently |
| stock + this patch only | 4 | 4/4 alive, correct state throughout |

## Note on semantics

This patch makes the write **fail cleanly** rather than corrupt the device. It does not decide
what *should* happen when a host writes a generated EF — arguably `cmd_update_ef` should return
a more specific status word than the `6581` that `PICOKEYS_ERR_BLOCKED` currently maps to, or
pico-hsm should accept and store an override for EF.TokenInfo. That is a semantic decision for
you; this change only removes the memory-safety failure.

Hardware scope: verified on a single Waveshare RP2350-PiZero (RP2350B) with a Raspberry Pi
Debug Probe. No RP2040 hardware here, so the RP2040 path is compile-checked only.
