### PR TITLE
fix(boot): disarm a stale watchdog in preinit — a slow boot turns watchdog_reboot() into a reset loop

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,41 @@
 #include "bsp/board.h"
 #include "hardware/structs/ioqspi.h"
 #include "pico/stdio.h"
+#include "hardware/watchdog.h"
+#include "pico/runtime_init.h"
+#endif
+
+#if defined(PICO_PLATFORM) && !defined(ENABLE_EMULATION)
+/* Disarm a stale watchdog before anything slow runs.
+ *
+ * watchdog_reboot() leaves the watchdog ENABLED across the reset it causes, and rescue.c's reboot
+ * command uses a 100 ms window. The boot must therefore complete before that window expires — and
+ * it does not always, because the startup flash filesystem scan grows with the number of files on
+ * the card. When it overruns, the watchdog fires again, and again, and the device never escapes.
+ * rom_reboot() does not avoid this: the bootrom implements reboot via the watchdog too.
+ *
+ * Root-caused by provoking the failure and reading the hardware while still in it, on RP2350B:
+ *
+ *     WATCHDOG_CTRL   = 0x40000000   ENABLE set, pause-on-debug clear
+ *     WATCHDOG_LOAD   = 0x00000000   countdown expired
+ *     WATCHDOG_REASON = 0x00000001   TIMER — the last reset WAS the watchdog
+ *
+ * The observable symptoms all follow from that: both cores report "running" but time out on every
+ * halt request (they are reset out from under the debugger), no firmware output appears at all
+ * (boot never reaches stdio), and the USB port shows "power connect" without "enable" because
+ * enumeration never completes. It survives a POWMAN power cycle AND a full VBUS cut, because the
+ * firmware re-arms the trap on the way back up.
+ *
+ * This MUST run before main(). A disarm at the top of main() was tried first and measured not to
+ * work — the loop resets before main() is ever reached, so the wedge reproduced unchanged. Only a
+ * preinit hook is early enough.
+ *
+ * Safe unconditionally: by the time any C code runs, the reset has already happened and its reboot
+ * vector has already been consumed. */
+static void picokeys_disarm_stale_watchdog(void) {
+    hw_clear_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);
+}
+PICO_RUNTIME_INIT_FUNC_HW(picokeys_disarm_stale_watchdog, PICO_RUNTIME_INIT_EARLIEST);
 #endif
 
 #include "random.h"


### PR DESCRIPTION
One file, one statement. Independent of my other PRs and of the report in #25.

## The bug

`watchdog_reboot()` leaves the watchdog **ENABLED across the reset it causes**. `rescue.c`'s reboot
command uses a 100 ms window, so the boot has to finish inside it — and it does not always, because
the startup flash filesystem scan grows with the number of files on the card. When it overruns, the
watchdog fires again, and again, and the device never escapes.

`rom_reboot()` does not avoid this: the bootrom implements reboot via the watchdog too. So no
choice of reboot API fixes it, and the fix cannot live in any one caller.

## Evidence

Provoked deliberately and read from the hardware while still in the failed state:

```
WATCHDOG_CTRL   = 0x40000000    ENABLE set, pause-on-debug clear
WATCHDOG_LOAD   = 0x00000000    countdown expired
WATCHDOG_REASON = 0x00000001    TIMER — the last reset WAS the watchdog
```

`REASON = TIMER` is the whole finding. Every symptom follows from it:

| symptom | why |
|---|---|
| both cores report `running` but time out on every `halt` | reset out from under the debugger |
| no firmware output at all | boot never reaches stdio |
| USB port shows `power connect` without `enable` | enumeration never completes |
| **survives a POWMAN cycle and a full VBUS cut** | the firmware re-arms the trap on the way up |

That last row is why this presents as dead hardware and costs a physical BOOTSEL: removing power
does not help when the first thing the firmware does on the way back is re-arm the same trap.

## Why preinit, and not main()

I tried the disarm at the top of `main()` first. **It was measured not to work** — the wedge
reproduced unchanged with `WATCHDOG_CTRL` still `0x40000000`, because the loop resets before
`main()` is ever reached.

What made that attempt convincing is worth flagging: it *does* run on healthy boots, so the
register reads clean whenever you check a working card. Only provoking the failure again showed it
had changed nothing.

Safe unconditionally — by the time any C runs, the reset has happened and its reboot vector is
already consumed.

## Verification

- **40 reboots via the rescue applet, 0 wedges**, against reproductions at reboot 23 and 37 on the
  two runs immediately before the fix.
- The card that produced the original evidence was recovered by BOOTSEL and reflashed by **UF2**,
  which rewrites only the program region and leaves the filesystem intact — so the state that
  triggered the fault was still present and the card booted through it.
- Syntax-checked for both RP2350 and RP2040 with the project's own build flags.

Hardware: one RP2350B (Waveshare RP2350-PiZero) with a Raspberry Pi Debug Probe. **No RP2040
hardware here** — the RP2040 side is compile-only.

## Note

This is deliberately minimal, per your request in #25 for focused changes that can be evaluated
independently. It does not touch `rescue.c`, the reset path, or anything else. Three of my earlier
PRs (#28, #29, #31) are now closed because my own follow-up measurements did not support them —
#31 in particular proposed a *deeper* reset for this failure, which was exactly backwards.