### PR TITLE
fix(fs): validate chain links during the scan — range and direction

### DIFF
--- a/src/fs/file.c
+++ b/src/fs/file.c
@@ -324,6 +324,14 @@ void file_initialize_flash(bool hard) {
 
 extern uintptr_t last_base;
 extern uint32_t num_files;
+/* Corrupt-filesystem state, exposed rather than silently swallowed. Set when scan_region() finds a
+ * chain link that is outside the region or does not move toward its start. The scan stops; nothing
+ * is erased. This keeps the linked-list pointers usable as integrity indicators and leaves the
+ * decision about a corrupt filesystem to the operator. */
+bool fs_corruption_detected = false;
+uintptr_t fs_corruption_addr = 0;   /* the offending link */
+uintptr_t fs_corruption_prev = 0;   /* the link before it, so direction is visible */
+
 static void scan_region(bool persistent) {
     uintptr_t endp = end_data_pool, startp = start_data_pool;
     if (persistent) {
@@ -334,10 +342,41 @@ static void scan_region(bool persistent) {
         last_base = endp;
         num_files = 0;
     }
+    uintptr_t prev_base = endp + 1;   /* links must move strictly toward startp */
     for (uintptr_t base = flash_read_uintptr(endp); base >= startp; base = flash_read_uintptr(base)) {
         if (base == 0x0) { //all is empty
             break;
         }
+
+        /* Validate the chain link before dereferencing it: inside the region, and strictly
+         * decreasing.
+         *
+         * The loop condition bounds `base` only from BELOW. Anything above the region passes it
+         * and is then read by the flash_read_*() calls that follow — including addresses that are
+         * not memory. Measured on RP2350B: a card stopped enumerating and survived reset, POWMAN
+         * cycles, VBUS cuts and a reflash. It was not wedged hardware; the core was parked in the
+         * bootrom exception handler with a precise bus fault, BFAR = 0x40130000 (peripheral space,
+         * neither flash nor SRAM). Every reset re-read the same link and faulted identically,
+         * which is why only erasing the filesystem recovered it.
+         *
+         * The strictly-decreasing test is not redundant with the range test: a link that points
+         * forward, or at itself, stays in range and yields an INFINITE SCAN instead of a fault —
+         * a different failure that a range check alone would hide.
+         *
+         * On detecting corruption this stops scanning and records what it saw. Nothing is erased,
+         * rewritten or skipped: the links stay usable as integrity indicators, the remaining data
+         * is left intact for inspection, and recovery stays an explicit decision rather than
+         * something the firmware does to itself. */
+        if (base > endp || base >= prev_base) {
+            fs_corruption_detected = true;
+            fs_corruption_addr = base;
+            fs_corruption_prev = prev_base;
+            printf("SCAN: chain link %x invalid (prev %x, region %x..%x) — stopping scan\n",
+                   (unsigned int) base, (unsigned int) prev_base,
+                   (unsigned int) startp, (unsigned int) endp);
+            break;
+        }
+        prev_base = base;
 
         uint16_t fid = flash_read_uint16(base + sizeof(uintptr_t) + sizeof(uintptr_t));
         uintptr_t length_addr = base + 2 * sizeof(uintptr_t) + sizeof(uint16_t);

--- a/src/fs/flash.h
+++ b/src/fs/flash.h
@@ -53,4 +53,10 @@ extern void low_flash_init(void);
 extern void flash_commit(void);
 extern bool flash_commit_sync(uint32_t timeout_ms);
 
+/* Corrupt-filesystem state set by scan_region() (src/fs/file.c). When a chain link fails
+ * validation the scan stops and records it here; nothing is erased. */
+extern bool fs_corruption_detected;
+extern uintptr_t fs_corruption_addr;
+extern uintptr_t fs_corruption_prev;
+
 #endif // _FLASH_H


### PR DESCRIPTION
Self-contained, one function. This is the change you specified in #25, and it does **not** depend
on #30 — it uses the `startp`/`endp` already local to `scan_region()`.

## The bug

`scan_region()` walks the chain with:

```c
for (uintptr_t base = flash_read_uintptr(endp); base >= startp; base = flash_read_uintptr(base)) {
```

That bounds `base` only from **below**. Anything above the region passes and is then dereferenced
by the `flash_read_*()` calls in the loop body — including addresses that are not memory.

## Evidence

A card stopped enumerating and survived `reset run`, POWMAN cycles, VBUS cuts on both its own and
the debug probe's ports, and a reflash. It was **not** wedged hardware:

```
pc   = 0x000003ec     bootrom exception handler
lr   = 0xfffffff9     EXC_RETURN — the core is inside an exception
CFSR = 0x00008200     BFSR 0x82: precise bus fault, BFAR valid
HFSR = 0x40000000     FORCED -> HardFault
BFAR = 0x40130000     peripheral space: neither flash nor SRAM
```

Every reset re-read the same link out of flash and faulted identically. That is why only erasing
the filesystem recovered it — and why it looked for a long time like hardware that survived power
cycles.

## What it does, per your specification

> `scan_flash()` should validate that every filesystem pointer remains within the configured region
> **and moves strictly toward the start of the region**. On detecting corruption, the firmware
> should **stop scanning and expose a controlled recovery state** rather than automatically erasing
> potentially valuable HSM data.

All three:

- **in region** — `base > endp` is rejected (the loop already covers `< startp`);
- **strictly decreasing** — not redundant with the range test: a link pointing forward or at itself
  stays in range and gives an **infinite scan** instead of a fault, a different failure that a
  range check alone would conceal;
- **controlled state** — `fs_corruption_detected` / `_addr` / `_prev`. Nothing is erased, rewritten
  or skipped. The scan stops, records the offending link and the one before it (so direction is
  visible), and leaves the data intact.

## On your objection

You wrote:

> I intentionally left the linked-list pointers as integrity indicators. Preventing the resulting
> HardFault by silently rejecting the address does not explain why a non-flash value reached
> `prev_addr`, and may hide the original failure.

Agreed, and that is why this reports rather than repairs. It does not skip the bad link and carry
on; it stops and says where. The pointers keep working as integrity indicators, and **the question
of how a non-flash value got there remains open** — I am not claiming this answers it.

I still owe you the flash-side forensics you asked for (raw record header, cached-sector copy,
`flash_pages` entries, and the original unaligned `prev_addr` from one halted state). The capture
is built and waiting on a reproduction; I sent fault registers last time, which do not distinguish
physical-flash corruption from a corrupted dirty-sector cache or an invalid `file->data`.

## Verification

- Syntax-checked for RP2350 and RP2040 with the project's own build flags.
- The card that produced the evidence was recovered by BOOTSEL and reflashed by **UF2**, which
  rewrites only the program region and leaves the filesystem intact — so the structure that caused
  the fault was still present, and the card booted through it.
- 60 reboots afterwards with 0 hard wedges.

One RP2350B (Waveshare RP2350-PiZero) with a Raspberry Pi Debug Probe. No RP2040 hardware here.